### PR TITLE
Fix broken css/js files on individual shaare pages

### DIFF
--- a/code_coloration/code_coloration.php
+++ b/code_coloration/code_coloration.php
@@ -18,7 +18,7 @@ function hook_code_coloration_render_includes($data, $conf)
     if ($data['_PAGE_'] == TemplatePage::LINKLIST) {
         $custom = $conf->get('plugins.CUSTOM_PRISM_CSS_FILENAME');
         $filename = !empty($custom) ? $custom : 'prism.css';
-        $data['css_files'][] = PluginManager::$PLUGINS_PATH . '/code_coloration/' . $filename;
+        $data['css_files'][] = ($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH . '/code_coloration/' . $filename;
     }
     return $data;
 }
@@ -37,7 +37,7 @@ function hook_code_coloration_render_footer($data, $conf)
     if ($data['_PAGE_'] == TemplatePage::LINKLIST) {
         $custom = $conf->get('plugins.CUSTOM_PRISM_JS_FILENAME');
         $filename = !empty($custom) ? $custom : 'prism.js';
-        $data['js_files'][] = PluginManager::$PLUGINS_PATH . '/code_coloration/'. $filename;
+        $data['js_files'][] = ($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH . '/code_coloration/'. $filename;
     }
     return $data;
 }


### PR DESCRIPTION
This PR fixes individual shaare pages (e.g., `/shaare/o3Fv-w`) as the relative path is no longer working:

![image](https://user-images.githubusercontent.com/21174107/92324725-a67eed80-f044-11ea-96e3-2cdbb9d023b5.png)
